### PR TITLE
LPS-55838 Breadcrump displays document title twice

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/asset/file_entry_full_content.jsp
+++ b/portal-web/docroot/html/portlet/document_library/asset/file_entry_full_content.jsp
@@ -18,6 +18,7 @@
 
 <%
 boolean showExtraInfo = ParamUtil.getBoolean(request, "showExtraInfo");
+request.setAttribute("includeBreadcrumb", Boolean.FALSE);		 
 %>
 
 <c:choose>

--- a/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_file_entry.jsp
@@ -672,5 +672,9 @@ DLViewFileVersionDisplayContext dlViewFileVersionDisplayContext = DLDisplayConte
 </aui:script>
 
 <%
-DLUtil.addPortletBreadcrumbEntries(fileEntry, request, renderResponse);
+boolean includeBreadcrumb = GetterUtil.getBoolean(request.getAttribute("includeBreadcrumb"), Boolean.TRUE);
+
+if(includeBreadcrumb){
+	DLUtil.addPortletBreadcrumbEntries(fileEntry, request, renderResponse);
+}
 %>


### PR DESCRIPTION
This time modifying the view on DL instead of AssetPublisher