### PR TITLE
LPS-77561

### DIFF
--- a/modules/apps/foundation/portal-template/portal-template-soy-impl/src/main/java/com/liferay/portal/template/soy/internal/SoyTemplate.java
+++ b/modules/apps/foundation/portal-template/portal-template-soy-impl/src/main/java/com/liferay/portal/template/soy/internal/SoyTemplate.java
@@ -228,6 +228,16 @@ public class SoyTemplate extends AbstractMultiResourceTemplate {
 			return value;
 		}
 
+		if (value instanceof Class) {
+			clazz = (Class)value;
+
+			return clazz.getName();
+		}
+
+		if (clazz.isEnum()) {
+			return String.valueOf(value);
+		}
+
 		if (clazz.isArray()) {
 			List<Object> newList = new ArrayList<>();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-77561

CI tests were executed successfully in https://github.com/jorgediaz-lr/liferay-portal/pull/170

StackOverflowError exception can be caused by:

1. Reference cycles (Map that contains a child with a reference to the map) 
2. We are following a lot of memory references that retrieves the whole memory.

To avoid that issues I have done following changes:

- **References cycles:** commit https://github.com/izaera/liferay-portal/pull/29/commits/837026d4720cd5a38d23cfede037ef90133c335f added a cache that avoid visiting same node twice
- **Avoid retrieving too much references:** commit https://github.com/izaera/liferay-portal/pull/29/commits/983967b9220b4f8647387165f26fc3112844746b:
The old code before LPS-76970 changes was doing a JSON deserialization / serialization using JODD library. That conversion was safer because Liferay service builder models have "@JSON" annotations that limits the fields to be serialized. That annotations are detected by JODD library (see: https://jodd.org/json/json-serializer.html#json-annotation ) during serialization
To avoid adding additional code that searchs that JSON annotations in service builder classes, I have added a call to the existing JSON deserialization / serialization and getting the fields names that I have to recurse in my code.
It is a bit tricky but avoids copying a lot of annotation handling code from JODD library. 

Regards,
Jorge Díaz

/cc: @antonio-ortega @jbalsas