### PR TITLE
[TECHNICAL-SUPPORT] LPS-86029

### DIFF
--- a/util-taglib/src/com/liferay/taglib/util/VelocityTaglibImpl.java
+++ b/util-taglib/src/com/liferay/taglib/util/VelocityTaglibImpl.java
@@ -34,7 +34,7 @@ import com.liferay.taglib.portletext.IconPortletTag;
 import com.liferay.taglib.portletext.RuntimeTag;
 import com.liferay.taglib.security.DoAsURLTag;
 import com.liferay.taglib.security.PermissionsURLTag;
-import com.liferay.taglib.servlet.PipingPageContext;
+import com.liferay.taglib.servlet.PageContextWrapper;
 import com.liferay.taglib.theme.LayoutIconTag;
 import com.liferay.taglib.theme.MetaTagsTag;
 import com.liferay.taglib.theme.WrapPortletTag;
@@ -927,7 +927,12 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 			writer = _response.getWriter();
 		}
 
-		tagSupport.setPageContext(new PipingPageContext(_pageContext, writer));
+		PageContextWrapper pageContextWrapper = new PageContextWrapper(
+			_pageContext);
+
+		pageContextWrapper.pushBody(writer);
+
+		tagSupport.setPageContext(pageContextWrapper);
 	}
 
 	private final Map<String, Object> _contextObjects;


### PR DESCRIPTION
Relevant tickets:
https://issues.liferay.com/browse/LPS-86029

When using a velocity based theme the portlet configuration options are not written inside of an unordered list and appear on the same level in the HTML as the 3 dots options button. This is caused by VelocityTaglibImpl using PipingPageContext to set up the Tag Support. Piping page context, however, does not replace the writer on each push body as does PipingContextWrapper which allows for JSP pages to be written inline and buffer the input to be written at the appropriate time on the page.

I Could not reproduce on master because I could not get a velocity theme to deploy, however, the underlying code is exactly the same between master and 7.0.x.