### PR TITLE
LPS-103179

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
+++ b/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
@@ -325,7 +325,9 @@ public class BrowserSnifferImpl implements BrowserSniffer {
 
 			String major = userAgent.substring(majorStart, majorEnd);
 
-			if (userAgent.charAt(majorEnd) != '.') {
+			if ((majorEnd >= userAgent.length()) ||
+				(userAgent.charAt(majorEnd) != '.')) {
+
 				return major;
 			}
 

--- a/portal-impl/test/unit/com/liferay/portal/servlet/BrowserSnifferImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/BrowserSnifferImplTest.java
@@ -121,13 +121,8 @@ public class BrowserSnifferImplTest {
 
 	@Test
 	public void testParseVersion() throws IOException {
-		Class<?> clazz = getClass();
-
 		try (UnsyncBufferedReader unsyncBufferedReader =
-				new UnsyncBufferedReader(
-					new InputStreamReader(
-						clazz.getResourceAsStream(
-							"dependencies/user_agents.csv")))) {
+				getResourceAsUnsyncBufferedReader()) {
 
 			String line = null;
 
@@ -169,43 +164,43 @@ public class BrowserSnifferImplTest {
 			String key, Consumer<MockHttpServletRequest> requestConsumer)
 		throws IOException {
 
-		UnsyncBufferedReader unsyncBufferedReader =
-			getResourceAsUnsyncBufferedReader("dependencies/user_agents.csv");
+		try (UnsyncBufferedReader unsyncBufferedReader =
+				getResourceAsUnsyncBufferedReader()) {
 
-		boolean matches = false;
-		String line = null;
+			boolean matches = false;
+			String line = null;
 
-		while ((line = unsyncBufferedReader.readLine()) != null) {
-			line = line.trim();
+			while ((line = unsyncBufferedReader.readLine()) != null) {
+				line = line.trim();
 
-			if (line.isEmpty()) {
-				continue;
-			}
+				if (line.isEmpty()) {
+					continue;
+				}
 
-			if (line.contains(key)) {
-				matches = true;
+				if (line.contains(key)) {
+					matches = true;
 
-				continue;
-			}
+					continue;
+				}
 
-			if (matches && (line.charAt(0) == CharPool.POUND)) {
-				break;
-			}
+				if (matches && (line.charAt(0) == CharPool.POUND)) {
+					break;
+				}
 
-			if (matches) {
-				MockHttpServletRequest mockHttpServletRequest =
-					new MockHttpServletRequest();
+				if (matches) {
+					MockHttpServletRequest mockHttpServletRequest =
+						new MockHttpServletRequest();
 
-				mockHttpServletRequest.addHeader(HttpHeaders.USER_AGENT, line);
+					mockHttpServletRequest.addHeader(
+						HttpHeaders.USER_AGENT, line);
 
-				requestConsumer.accept(mockHttpServletRequest);
+					requestConsumer.accept(mockHttpServletRequest);
+				}
 			}
 		}
 	}
 
-	protected UnsyncBufferedReader getResourceAsUnsyncBufferedReader(
-		String name) {
-
+	protected UnsyncBufferedReader getResourceAsUnsyncBufferedReader() {
 		Class<?> clazz = getClass();
 
 		return new UnsyncBufferedReader(

--- a/portal-impl/test/unit/com/liferay/portal/servlet/BrowserSnifferImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/BrowserSnifferImplTest.java
@@ -140,11 +140,15 @@ public class BrowserSnifferImplTest {
 
 				String[] parts = StringUtil.split(line, CharPool.COMMA);
 
-				if (parts.length != 4) {
+				if (parts.length < 4) {
 					continue;
 				}
 
 				String userAgent = parts[3].trim();
+
+				if (parts.length == 5) {
+					userAgent += ", " + parts[4].trim();
+				}
 
 				Assert.assertEquals(
 					parts[0].trim() + " version", parts[1].trim(),

--- a/portal-impl/test/unit/com/liferay/portal/servlet/dependencies/user_agents.csv
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/dependencies/user_agents.csv
@@ -166,6 +166,10 @@ IE 6 var18, , 6.0, mozilla/4.0 (compatible; u; msie 6.0; windows nt 5.1)
 IE 6 var19, , 6.0, mozilla/4.0 (compatible; msie 6.0; windows nt 6.1; mozilla/4.0 (compatible; msie 6.0; windows nt 5.1; sv1) ; slcc2; .net clr 2.0.50727; .net clr 3.5.30729; .net clr 3.0.30729; media center pc 6.0; .net4.0c; infopath.3; tablet pc 2.0)
 IE 6 var20, , 6.0, mozilla/4.0 (compatible; msie 6.0; windows nt 6.1; gtb6.5; qqdownload 534; mozilla/4.0 (compatible; msie 6.0; windows nt 5.1; sv1) ; slcc2; .net clr 2.0.50727; media center pc 6.0; .net clr 3.5.30729; .net clr 3.0.30729)
 
+
+## iOS
+iOS var1, , 1, Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Safari IPhoneAppVersion/2.6.87 rv:1
+
 ## Mobile
 
 mozilla/5.0 (linux; android 4.3; nexus 4 build/jwr66y) applewebkit/537.36 (khtml, like gecko) chrome/30.0.1599.82 mobile safari/537.36

--- a/portal-impl/test/unit/com/liferay/portal/servlet/dependencies/user_agents.csv
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/dependencies/user_agents.csv
@@ -42,7 +42,7 @@ Chrome 27 var4, 27.0, 537.36, mozilla/5.0 (macintosh; intel mac os x 10_7_5) app
 
 ## Edge
 
-Edge 12 var1, , 12.0, mozilla/5.0 (windows nt 10.0) applewebkit/537.36 (khtml, like gecko) chrome/42.0.2311.135 safari/537.36 edge/12.10136
+Edge 12 var1, 12.10136, 537.36, mozilla/5.0 (windows nt 10.0) applewebkit/537.36 (khtml, like gecko) chrome/42.0.2311.135 safari/537.36 edge/12.10136
 
 ## Firefox
 


### PR DESCRIPTION
Resending from https://github.com/jbalsas/liferay-portal/pull/1981

https://github.com/izaera/liferay-portal/commit/40f69f088b4abdb4b93a407946e4aa497939b440 Adds a test that highlights the issue being resolved by LPS-103179 by having the trailing `rv` in the user-agent string.

https://github.com/izaera/liferay-portal/commit/48a3076fc7f7a2996dd2231ba336c69d7478c0c7 Without this the previous user-agent string and a number of others will not be run through the `testParseVersion` method. The other way to resolve this would be to remove `(khtml, like gecko)` from the user-agent string but I thought it'd be better to leave the user-agent strings as is and introduce additional logic to the test. If you see a better alternative please let me know.

https://github.com/izaera/liferay-portal/pull/114/commits/5fbe83b6ee74dadcfd6c91f3f4421df2685a5221 This is general clean up of the test.

Thank you.