### PR TITLE
Git merge driver for node-scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.pom	text eol=lf
 .m2-tmp/**/*.pom linguist-generated=true
 ivy.xml	text eol=lf
+modules/_node-scripts/package.json merge=node-scripts

--- a/modules/_node-scripts/bin.js
+++ b/modules/_node-scripts/bin.js
@@ -64,6 +64,11 @@ const COMMANDS = {
 			'--current=<current file> --base=<base file> --other=<other file>',
 		script: './gitmerge/self.mjs',
 	},
+	'gitmerge:setup': {
+		description: 'adds gitmerge:self to .git/config file',
+		parameters: '',
+		script: './gitmerge/setup.mjs',
+	},
 	'setup': {
 		description: 'setup working environment used by node-scripts',
 		parameters: '',

--- a/modules/_node-scripts/bin.js
+++ b/modules/_node-scripts/bin.js
@@ -58,6 +58,12 @@ const COMMANDS = {
 		parameters: '',
 		script: './tsconfig/index.mjs',
 	},
+	'gitmerge:self': {
+		description: `implements a Git merge driver for node-scripts' package.json file`,
+		parameters:
+			'--current=<current file> --base=<base file> --other=<other file>',
+		script: './gitmerge/self.mjs',
+	},
 	'setup': {
 		description: 'setup working environment used by node-scripts',
 		parameters: '',

--- a/modules/_node-scripts/gitmerge/self.mjs
+++ b/modules/_node-scripts/gitmerge/self.mjs
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fs from 'fs/promises';
+
+import digestNodeScripts from '../util/digestNodeScripts.mjs';
+import getNamedArguments from '../util/getNamedArguments.mjs';
+import objectSF from '../util/objectSF.mjs';
+
+export default async function main() {
+	const {current} = getNamedArguments({
+		base: '--base',
+		current: '--current',
+		other: '--other',
+	});
+
+	const contents = await fs.readFile(current, 'utf-8');
+	const lines = contents.split('\n');
+
+	let inConflict = false;
+	const nonConflictLines = [];
+
+	for (const line of lines) {
+		const trimLine = line.trim();
+
+		if (trimLine.startsWith('<<<<<<<')) {
+			inConflict = true;
+		}
+		else if (trimLine.startsWith('>>>>>>>')) {
+			inConflict = false;
+		}
+		else if (inConflict) {
+			if (
+				!trimLine.startsWith('=======') &&
+				!trimLine.startsWith('"sha256": "')
+			) {
+
+				// At least one conflict line is not related to hash so fail merge
+
+				process.exit(1);
+			}
+		}
+		else {
+			nonConflictLines.push(line);
+		}
+	}
+
+	const json = JSON.parse(nonConflictLines.join('\n'));
+
+	json['com.liferay']['sha256'] = await digestNodeScripts();
+
+	await fs.writeFile(current, objectSF(json), 'utf-8');
+
+	process.exit(0);
+}

--- a/modules/_node-scripts/gitmerge/setup.mjs
+++ b/modules/_node-scripts/gitmerge/setup.mjs
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+
+import {getRootDir} from '../util/constants.mjs';
+
+export default async function main() {
+	const rootDir = await getRootDir();
+	const gitConfigPath = path.resolve(rootDir, '..', '.git', 'config');
+
+	let contents = await fs.readFile(gitConfigPath, 'utf-8');
+
+	if (contents.includes('[merge "node-scripts"]')) {
+		console.log(`
+⚠️ Git merge driver for node-scripts is already configured: doing nothing 🦥
+`);
+		process.exit(3);
+	}
+
+	if (contents.endsWith('\n')) {
+		contents = contents.substring(0, contents.length - 1);
+	}
+
+	await fs.writeFile(
+		gitConfigPath,
+		`${contents}
+[merge "node-scripts"]
+	name = node-scripts conflicts merger
+	driver = build/node/bin/node modules/_node-scripts/bin.js gitmerge:self --current=%A --base=%B --other=%O
+	recursive = text
+`,
+		'utf-8'
+	);
+
+	console.log(`
+✅ Added Git merge driver for node-scripts to .git/config file 🎉
+`);
+}

--- a/modules/_node-scripts/package.json
+++ b/modules/_node-scripts/package.json
@@ -4,7 +4,7 @@
 		"node-scripts": "./bin.js"
 	},
 	"com.liferay": {
-		"sha256": "d6ba5429568f6de585ab581044839d81993e14c0e6d00d8c1cd1264d6547c98b"
+		"sha256": "f7ba02a7df363e05e2d0c2a4b46c6a618d7a37b7d7eddc206a8c6c166436a520"
 	},
 	"dependencies": {
 		"@babel/preset-env": "7.24.7",


### PR DESCRIPTION
This PR implements an automatic git merge driver that updates the `sha256`  field of `node-scripts` when a rebase conflict happens.

It is based on this Git's feature -> https://git-scm.com/docs/gitattributes#_defining_a_custom_merge_driver

Once this PR is merged, anyone willing to use the merge driver just needs to run `yarn node-scripts gitmerge:setup` at their `liferay-portal` repo and that will configure the driver in their local `.git/config` file so that it is used whenever a conflict in `modules/_node-scripts/package.json` arises (as configured here in this PR -> https://github.com/izaera/liferay-portal/pull/173/files#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR4).

----

:warning: **The only important caveat** is that for the driver to work, the commits that update `node-scripts`' hash field must be added to the end of each PR (like in this one, here -> https://github.com/izaera/liferay-portal/pull/173/commits/7339b36b8a862957dcd44a71574fbafa008f9726).

This is because otherwise, if the "update hash" commit is in the middle of a PR, the merge driver will use an invalid hash to resolve the conflict since it cannot see the following commits.