### PR TITLE
LPD-88400 Enable CKEditor 4 (LPD-11235 feature flag) for all poshi tests

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -13555,6 +13555,14 @@ feature.flag.LPD-11342=true</echo>
 			</then>
 		</if>
 
+		<if>
+			<equals arg1="${functional.test.type}" arg2="poshi" />
+			<then>
+				<echo append="true" file="portal-impl/src/portal-ext.properties">
+feature.flag.LPD-11235=true</echo>
+			</then>
+		</if>
+
 		<echo append="true" file="portal-impl/src/portal-ext.properties">
 analytics.cloud.domain.allowed=*</echo>
 


### PR DESCRIPTION
Reworked version of liferay-frontend/liferay-portal#5459 (CKEditor 4 for legacy Poshi tests).

Instead of toggling the flag at runtime via the headless feature-flag endpoint, this sets `feature.flag.LPD-11235=true` in `portal-ext.properties` during `prepare-portal-ext-properties` — the same mechanism the existing `feature.flag.LPD-11342` line just above it uses. The flag is applied before the portal boots, so it's live from the first request.

It is gated on `functional.test.type=poshi`, so it only affects legacy Poshi functional batches; integration and Playwright runs are unaffected.

This drops the portal-instances lookup, the company-id parsing, and the per-company POST: on a freshly provisioned CI instance there is no per-company feature-flag preference, so the portal property is what takes effect (PreferenceAwareFeatureFlag falls back to it when no override exists).

Baseline comparison from the original PR:
https://testray.liferay.com/#/project/473116959/routines/473359709/build/475529192

Note: I have not yet booted a bundle to confirm CKEditor 4 actually loads with the flag set this way — worth a smoke check before relying on it.